### PR TITLE
Fixes support for Sendy 4.0.3.3

### DIFF
--- a/src/Sendy.php
+++ b/src/Sendy.php
@@ -85,7 +85,8 @@ class Sendy
         if(!self::isEmailValid($email))
             throw new Exception\InvalidEmailException($email);
 
-        $request = array(   'email'=>$email,
+        $request = array(   'api_key'=>$this->_getApiKey(),
+                            'email'=>$email,
                             'list'=>$listID,
                             'boolean' => 'true');
         if(!is_null($name))
@@ -127,7 +128,8 @@ class Sendy
         if(!self::isEmailValid($email))
             throw new Exception\InvalidEmailException($email);
 
-        $request = array(   'email'=>$email,
+        $request = array(   'api_key'=>$this->_getApiKey(),
+                            'email'=>$email,
                             'list'=>$listID,
                             'boolean' => 'true');
 


### PR DESCRIPTION
https://sendy.co/get-updated

> Previously the subscribe API is secured by the AES-256-CBC encrypted list ID. To make the subscribe API more secure and less prone to abuse, this update requires you to pass your API key into the call with the api_key parameter.

>Important: If you’re currently using the subscribe API call in your website or application, add a new parameter api_key to your API call with your API key wherever you use the subscribe API. 